### PR TITLE
feat: GitHub MCP 서버 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ replay_pid*
 # OS specific
 .DS_Store
 Thumbs.db
+
+# MCP Server
+mcp-server/node_modules/
+mcp-server/config/config.json
+.env

--- a/mcp-server/config/config.example.json
+++ b/mcp-server/config/config.example.json
@@ -1,0 +1,11 @@
+{
+  "github": {
+    "token": "YOUR_GITHUB_TOKEN_HERE",
+    "defaultOwner": "",
+    "defaultRepo": ""
+  },
+  "server": {
+    "name": "github-mcp-server",
+    "version": "1.0.0"
+  }
+}

--- a/mcp-server/githubService.js
+++ b/mcp-server/githubService.js
@@ -1,0 +1,138 @@
+import { Octokit } from '@octokit/rest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Load config
+const configPath = join(__dirname, 'config', 'config.json');
+const config = JSON.parse(readFileSync(configPath, 'utf8'));
+
+// Initialize Octokit with GitHub token
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN || config.github.token
+});
+
+export const githubService = {
+  // Get repository information
+  async getRepository(owner, repo) {
+    const { data } = await octokit.repos.get({ owner, repo });
+    return data;
+  },
+
+  // List repositories for a user
+  async listRepositories(username) {
+    const { data } = await octokit.repos.listForUser({ username });
+    return data;
+  },
+
+  // Get repository contents
+  async getContents(owner, repo, path = '') {
+    const { data } = await octokit.repos.getContent({ owner, repo, path });
+    return data;
+  },
+
+  // Create a new issue
+  async createIssue(owner, repo, title, body) {
+    const { data } = await octokit.issues.create({
+      owner,
+      repo,
+      title,
+      body
+    });
+    return data;
+  },
+
+  // List issues
+  async listIssues(owner, repo, state = 'open') {
+    const { data } = await octokit.issues.listForRepo({
+      owner,
+      repo,
+      state
+    });
+    return data;
+  },
+
+  // Get a specific issue
+  async getIssue(owner, repo, issueNumber) {
+    const { data } = await octokit.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber
+    });
+    return data;
+  },
+
+  // Create a pull request
+  async createPullRequest(owner, repo, title, body, head, base) {
+    const { data } = await octokit.pulls.create({
+      owner,
+      repo,
+      title,
+      body,
+      head,
+      base
+    });
+    return data;
+  },
+
+  // List pull requests
+  async listPullRequests(owner, repo, state = 'open') {
+    const { data } = await octokit.pulls.list({
+      owner,
+      repo,
+      state
+    });
+    return data;
+  },
+
+  // Get commits
+  async listCommits(owner, repo, perPage = 10) {
+    const { data } = await octokit.repos.listCommits({
+      owner,
+      repo,
+      per_page: perPage
+    });
+    return data;
+  },
+
+  // Get branches
+  async listBranches(owner, repo) {
+    const { data } = await octokit.repos.listBranches({ owner, repo });
+    return data;
+  },
+
+  // Search code
+  async searchCode(query) {
+    const { data } = await octokit.search.code({ q: query });
+    return data;
+  },
+
+  // Get file content
+  async getFileContent(owner, repo, path) {
+    const { data } = await octokit.repos.getContent({ owner, repo, path });
+    if (data.content) {
+      return Buffer.from(data.content, 'base64').toString('utf8');
+    }
+    return data;
+  },
+
+  // Create or update file
+  async createOrUpdateFile(owner, repo, path, message, content, sha = null) {
+    const params = {
+      owner,
+      repo,
+      path,
+      message,
+      content: Buffer.from(content).toString('base64')
+    };
+    if (sha) params.sha = sha;
+
+    const { data } = await octokit.repos.createOrUpdateFileContents(params);
+    return data;
+  }
+};
+
+export default githubService;

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1,0 +1,242 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { githubService } from './githubService.js';
+
+// Create MCP server
+const server = new Server(
+  {
+    name: 'github-mcp-server',
+    version: '1.0.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// Define available tools
+const TOOLS = [
+  {
+    name: 'get_repository',
+    description: 'Get information about a GitHub repository',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+      },
+      required: ['owner', 'repo'],
+    },
+  },
+  {
+    name: 'list_repositories',
+    description: 'List repositories for a GitHub user',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        username: { type: 'string', description: 'GitHub username' },
+      },
+      required: ['username'],
+    },
+  },
+  {
+    name: 'get_contents',
+    description: 'Get contents of a repository directory or file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        path: { type: 'string', description: 'Path to file or directory' },
+      },
+      required: ['owner', 'repo'],
+    },
+  },
+  {
+    name: 'create_issue',
+    description: 'Create a new issue in a repository',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        title: { type: 'string', description: 'Issue title' },
+        body: { type: 'string', description: 'Issue body' },
+      },
+      required: ['owner', 'repo', 'title'],
+    },
+  },
+  {
+    name: 'list_issues',
+    description: 'List issues in a repository',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        state: { type: 'string', enum: ['open', 'closed', 'all'], description: 'Issue state' },
+      },
+      required: ['owner', 'repo'],
+    },
+  },
+  {
+    name: 'get_issue',
+    description: 'Get a specific issue by number',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        issue_number: { type: 'number', description: 'Issue number' },
+      },
+      required: ['owner', 'repo', 'issue_number'],
+    },
+  },
+  {
+    name: 'list_pull_requests',
+    description: 'List pull requests in a repository',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        state: { type: 'string', enum: ['open', 'closed', 'all'], description: 'PR state' },
+      },
+      required: ['owner', 'repo'],
+    },
+  },
+  {
+    name: 'list_commits',
+    description: 'List recent commits in a repository',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        per_page: { type: 'number', description: 'Number of commits to return' },
+      },
+      required: ['owner', 'repo'],
+    },
+  },
+  {
+    name: 'list_branches',
+    description: 'List branches in a repository',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+      },
+      required: ['owner', 'repo'],
+    },
+  },
+  {
+    name: 'search_code',
+    description: 'Search for code across GitHub repositories',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'get_file_content',
+    description: 'Get the content of a specific file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        path: { type: 'string', description: 'Path to file' },
+      },
+      required: ['owner', 'repo', 'path'],
+    },
+  },
+];
+
+// Handle list tools request
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools: TOOLS };
+});
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    let result;
+
+    switch (name) {
+      case 'get_repository':
+        result = await githubService.getRepository(args.owner, args.repo);
+        break;
+      case 'list_repositories':
+        result = await githubService.listRepositories(args.username);
+        break;
+      case 'get_contents':
+        result = await githubService.getContents(args.owner, args.repo, args.path || '');
+        break;
+      case 'create_issue':
+        result = await githubService.createIssue(args.owner, args.repo, args.title, args.body || '');
+        break;
+      case 'list_issues':
+        result = await githubService.listIssues(args.owner, args.repo, args.state || 'open');
+        break;
+      case 'get_issue':
+        result = await githubService.getIssue(args.owner, args.repo, args.issue_number);
+        break;
+      case 'list_pull_requests':
+        result = await githubService.listPullRequests(args.owner, args.repo, args.state || 'open');
+        break;
+      case 'list_commits':
+        result = await githubService.listCommits(args.owner, args.repo, args.per_page || 10);
+        break;
+      case 'list_branches':
+        result = await githubService.listBranches(args.owner, args.repo);
+        break;
+      case 'search_code':
+        result = await githubService.searchCode(args.query);
+        break;
+      case 'get_file_content':
+        result = await githubService.getFileContent(args.owner, args.repo, args.path);
+        break;
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Start server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('GitHub MCP Server running on stdio');
+}
+
+main().catch(console.error);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "github-mcp-server",
+  "version": "1.0.0",
+  "description": "MCP Server for GitHub integration with Claude",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@octokit/rest": "^21.0.0",
+    "dotenv": "^16.3.1"
+  },
+  "keywords": ["mcp", "github", "claude"],
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- Claude Code와 GitHub 연동을 위한 MCP 서버 추가
- Repository, Issue, PR, Commit 등 GitHub API 기능 지원
- 팀 협업 시 Claude를 통한 GitHub 작업 자동화 가능

## 추가된 파일
- `mcp-server/index.js` - MCP 서버 메인
- `mcp-server/githubService.js` - GitHub API 서비스
- `mcp-server/package.json` - 의존성 관리
- `mcp-server/config/config.example.json` - 설정 예시

## 사용 방법
1. `cd mcp-server && npm install`
2. `config/config.example.json`을 `config/config.json`으로 복사
3. GitHub 토큰 설정
4. Claude Code에서 MCP 서버 등록

## Test plan
- [ ] npm install 정상 동작 확인
- [ ] MCP 서버 실행 확인
- [ ] GitHub API 연동 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)